### PR TITLE
Working around ordering issue with embedded reources in MSBuild

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Yarn install
         run: yarn
 
+      - name: Build workbench (TEMPORARY STEP)
+        run: |
+          pushd .
+          cd Source/Workbench/Events/Web
+          yarn build
+          cp -r wwwroot/. ../../../Clients/AspNetCore/workbench/
+          popd
+
       - name: Setup .Net
         uses: actions/setup-dotnet@v1
         with:

--- a/Source/Clients/AspNetCore/AspNetCore.csproj
+++ b/Source/Clients/AspNetCore/AspNetCore.csproj
@@ -17,6 +17,7 @@
         <PropertyGroup>
             <WorkbenchDirectory>$(MSBuildThisFileDirectory)../../Workbench/Events/Web</WorkbenchDirectory>
         </PropertyGroup>
+
         <ItemGroup>
             <FilesToCopy Include="$(WorkbenchDirectory)/wwwroot/**/*" />
         </ItemGroup>


### PR DESCRIPTION
### Fixed

- Building Workbench in GitHub workflow as a workaround.
