### PR TITLE
Adding prefix paths for WebPack output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           pushd .
           cd Source/Workbench/Events/Web
-          yarn build
+          base_path=/events/ yarn build
           cp -r wwwroot/. ../../../Clients/AspNetCore/workbench/
           popd
 

--- a/Source/Clients/AspNetCore/AspNetCore.csproj
+++ b/Source/Clients/AspNetCore/AspNetCore.csproj
@@ -16,7 +16,6 @@
     <ItemGroup>
         <EmbeddedResource Include="$(MSBuildThisFileDirectory)/workbench/**/*"/>
     </ItemGroup>
-
     <!--
     <Target Name="BuildWorkbench" Condition="$(Configuration) == 'Release'" BeforeTargets="BeforeBuild">
         <PropertyGroup>


### PR DESCRIPTION
### Fixed

- Index.html for Workbench now has the correct `/events` prefix for all file references.