### PR TITLE
Changing from Use* to Add* - more common

### DIFF
--- a/Samples/AspNetCore/Startup.cs
+++ b/Samples/AspNetCore/Startup.cs
@@ -7,7 +7,7 @@ namespace AspNetCore
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            services.UseCratisWorkbench();
+            services.AddCratisWorkbench();
         }
 
         public void Configure(IApplicationBuilder app)

--- a/Samples/Dolittle/Startup.cs
+++ b/Samples/Dolittle/Startup.cs
@@ -13,8 +13,8 @@ namespace Sample
         {
             services.AddRazorPages();
             services.AddSingleton(Types);
-            services.UseDolittleSchemaStore("localhost", 27017);
-            services.UseCratisWorkbench();
+            services.AddDolittleSchemaStore("localhost", 27017);
+            services.AddCratisWorkbench();
         }
 
         public void Configure(IApplicationBuilder app)

--- a/Source/Clients/AspNetCore.Workbench/ServiceCollectionExtensions.cs
+++ b/Source/Clients/AspNetCore.Workbench/ServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services"><see cref="IServiceCollection"/> to build on.</param>
         /// <returns><see cref="IServiceCollection"/> for configuration continuation.</returns>
-        public static IServiceCollection UseCratisWorkbench(this IServiceCollection services)
+        public static IServiceCollection AddCratisWorkbench(this IServiceCollection services)
         {
             services.AddControllers().AddJsonOptions(_ => _.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull);
             return services;

--- a/Source/Clients/AspNetCore.Workbench/WebApplicationBuilderExtensions.cs
+++ b/Source/Clients/AspNetCore.Workbench/WebApplicationBuilderExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns><see cref="WebApplicationBuilder"/> for configuration continuation.</returns>
         public static WebApplicationBuilder UseCratisWorkbench(this WebApplicationBuilder webApplicationBuilder)
         {
-            webApplicationBuilder.Services.UseCratisWorkbench();
+            webApplicationBuilder.Services.AddCratisWorkbench();
             return webApplicationBuilder;
         }
     }

--- a/Source/Extensions/Dolittle/Schemas/ServiceCollectionExtensions.cs
+++ b/Source/Extensions/Dolittle/Schemas/ServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="mongoDBHost">The MongoDB hostname.</param>
         /// <param name="mongoDBPort">The MongoDB port.</param>
         /// <returns><see cref="IServiceCollection"/> for configuration continuation.</returns>
-        public static IServiceCollection UseDolittleSchemaStore(this IServiceCollection services, string mongoDBHost, int mongoDBPort)
+        public static IServiceCollection AddDolittleSchemaStore(this IServiceCollection services, string mongoDBHost, int mongoDBPort)
         {
             services.AddSingleton(new SchemaStoreConfiguration(mongoDBHost, mongoDBPort));
             return services;


### PR DESCRIPTION
### Fixed

- Fixing ServiceCollection extension APIs from version 2.4.0. Instead of `Use*`for the methods, its now `Add*`. Should've been major version, but since this mistake was done 20 minutes ago - no one has consumed it yet :). 

