### PR TITLE
Fixing embedding of SPA for Events Workbench

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
           pushd .
           cd Source/Workbench/Events/Web
           base_path=/events/ yarn build
-          cp -r wwwroot/. ../../../Clients/AspNetCore/workbench/
+          cp -r wwwroot/. ../../../Clients/AspNetCore.Workbench/workbench/
           popd
 
       - name: Setup .Net

--- a/Source/Clients/AspNetCore.Workbench/Root.cs
+++ b/Source/Clients/AspNetCore.Workbench/Root.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Cratis.AspNetCore
+namespace Cratis.AspNetCore.Workbench
 {
     /// <summary>
     /// A class making things more refactor friendly if we change namespace or similar. Used in ApplicationBuilderExtensions.


### PR DESCRIPTION
### Fixed

- Fixing build that creates the embedded version of the Events Workbench after restructuring. This got broken in 2.4.0.
