### PR TITLE
Fixing namespace reference

### DIFF
--- a/Source/Clients/AspNetCore.Workbench/ApplicationBuilderExtensions.cs
+++ b/Source/Clients/AspNetCore.Workbench/ApplicationBuilderExtensions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.AspNetCore;
+using Cratis.AspNetCore.Workbench;
 using Microsoft.AspNetCore.StaticFiles.Infrastructure;
 using Microsoft.Extensions.FileProviders;
 


### PR DESCRIPTION
### Fixed

- Fixing build that creates the embedded version of the Events Workbench after restructuring. This got broken in 2.4.0.