### PR TITLE
Making sure serializers are registered properly

### DIFF
--- a/Samples/Dolittle/Startup.cs
+++ b/Samples/Dolittle/Startup.cs
@@ -12,16 +12,17 @@ namespace Sample
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddRazorPages();
-            services.AddSingleton(Types);
-            services.AddDolittleSchemaStore("localhost", 27017);
-            services.AddCratisWorkbench();
+            services.AddSingleton(Types)
+                .AddDolittleSchemaStore("localhost", 27017)
+                .AddCratisWorkbench();
         }
 
         public void Configure(IApplicationBuilder app)
         {
-            app.UseRouting();
-            app.UseDolittleSchemaStore();
-            app.UseCratisWorkbench();
+            app
+                .UseRouting()
+                .UseDolittleSchemaStore()
+                .UseCratisWorkbench();
         }
     }
 }

--- a/Source/Clients/AspNetCore.Workbench/ApplicationBuilderExtensions.cs
+++ b/Source/Clients/AspNetCore.Workbench/ApplicationBuilderExtensions.cs
@@ -31,8 +31,8 @@ namespace Microsoft.AspNetCore.Builder
             applicationBuilder.UseDefaultFiles(new DefaultFilesOptions(filesOptions));
             applicationBuilder.UseStaticFiles(new StaticFileOptions(filesOptions));
 
-            applicationBuilder.UseEndpoints(_ => _.MapControllers());
             applicationBuilder.PerformBootProcedures();
+            applicationBuilder.UseEndpoints(_ => _.MapControllers());
             applicationBuilder.RunAsSinglePageApplication(filesOptions);
 
             return applicationBuilder;

--- a/Source/Extensions/Dolittle/Schemas/ApplicationBuilderExtensions.cs
+++ b/Source/Extensions/Dolittle/Schemas/ApplicationBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Extensions.Dolittle.Schemas;
+using Cratis.Extensions.MongoDB;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Builder
@@ -18,6 +19,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <returns><see cref="IApplicationBuilder"/> for continuation.</returns>
         public static IApplicationBuilder UseDolittleSchemaStore(this IApplicationBuilder applicationBuilder)
         {
+            MongoDBDefaults.Initialize();
             applicationBuilder
                 .ApplicationServices
                 .GetService<ISchemaStore>()?

--- a/Source/Extensions/MongoDB/MongoDBDefaults.cs
+++ b/Source/Extensions/MongoDB/MongoDBDefaults.cs
@@ -13,11 +13,16 @@ namespace Cratis.Extensions.MongoDB
     /// </summary>
     public static class MongoDBDefaults
     {
+        static bool _initialized;
+
         /// <summary>
         /// Initialize the defaults.
         /// </summary>
         public static void Initialize()
         {
+            if( _initialized ) return;
+            _initialized = true;
+
             BsonSerializer
                 .RegisterSerializationProvider(
                     new ConceptSerializationProvider()


### PR DESCRIPTION
### Fixed

- Fixing a bug where Bson serializer for Guid already exists when we get to setting up how we want it setup. Turns out that the MongoDB driver will configure a bunch of serializers default if you create a MongoClient, if you then do a registration of a serializer after that - its too late. This fix makes sure we do it before.
