### PR TITLE
Removing private field - not needed and tooling breaks

### DIFF
--- a/Source/Node/FluentUI/package.json
+++ b/Source/Node/FluentUI/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@cratis/fluentui",
-    "version": "1.0.0",
+    "version": "2.6.1",
     "description": "",
-    "private": "false",
     "author": "Cratis",
     "license": "MIT",
     "files": [
@@ -21,12 +20,12 @@
         "ci": "yarn clean && yarn lint:ci && yarn build && yarn test"
     },
     "dependencies": {
+        "@cratis/typescript": "2.6.1",
         "@fluentui/font-icons-mdl2": "8.1.11",
         "@fluentui/react": "8.34.7",
         "@fluentui/react-charting": "5.3.46",
         "@fluentui/react-hooks": "8.3.2",
-        "@fluentui/react-icons": "1.1.141",
-        "@cratis/typescript": "2.6.1"
+        "@fluentui/react-icons": "1.1.141"
     },
     "devDependencies": {}
 }

--- a/Source/Node/FluentUI/package.json
+++ b/Source/Node/FluentUI/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cratis/fluentui",
-    "version": "2.6.1",
+    "version": "1.0.0",
     "description": "",
     "author": "Cratis",
     "license": "MIT",
@@ -20,7 +20,7 @@
         "ci": "yarn clean && yarn lint:ci && yarn build && yarn test"
     },
     "dependencies": {
-        "@cratis/typescript": "2.6.1",
+        "@cratis/typescript": "1.0.0",
         "@fluentui/font-icons-mdl2": "8.1.11",
         "@fluentui/react": "8.34.7",
         "@fluentui/react-charting": "5.3.46",

--- a/Source/Node/Fundamentals/package.json
+++ b/Source/Node/Fundamentals/package.json
@@ -2,7 +2,6 @@
     "name": "@cratis/fundamentals",
     "version": "1.0.0",
     "description": "",
-    "private": "false",
     "author": "Cratis",
     "license": "MIT",
     "files": [

--- a/Source/Node/React/package.json
+++ b/Source/Node/React/package.json
@@ -2,7 +2,6 @@
     "name": "@cratis/react",
     "version": "1.0.0",
     "description": "",
-    "private": "false",
     "author": "Cratis",
     "license": "MIT",
     "files": [

--- a/Source/Node/TypeScript/package.json
+++ b/Source/Node/TypeScript/package.json
@@ -2,7 +2,6 @@
     "name": "@cratis/typescript",
     "version": "1.0.0",
     "description": "",
-    "private": "false",
     "author": "Cratis",
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
### Fixed

- Remove `"private":false`  from all package.json files. This broke NPM publish claiming the packages were private.