### PR TITLE
Project-referenced-assemblies

### DIFF
--- a/Source/Fundamentals/Types/ITypes.cs
+++ b/Source/Fundamentals/Types/ITypes.cs
@@ -16,6 +16,11 @@ namespace Cratis.Types
         IEnumerable<Assembly> Assemblies { get; }
 
         /// <summary>
+        /// Gets all the assemblies referenced as a project reference.
+        /// </summary>
+        IEnumerable<Assembly> ProjectReferencedAssemblies { get; }
+
+        /// <summary>
         /// Gets returns all collected types.
         /// </summary>
         IEnumerable<Type> All { get; }

--- a/Source/Node/TypeScript/package.json
+++ b/Source/Node/TypeScript/package.json
@@ -16,7 +16,9 @@
         "test": "mocha",
         "ci": "yarn clean && yarn lint:ci && yarn build && yarn test"
     },
-    "dependencies": {},
+    "dependencies": {
+        "reflect-metadata": "^0.1.13"
+    },
     "devDependencies": {
         "@types/chai": "4.2.21",
         "@types/chai-as-promised": "7.1.4",


### PR DESCRIPTION
### Added

- [C#] `ITypes` now have a property called `ProjectReferencedAssemblies` - enabling you to see all project referenced assemblies discovered.