### PR TITLE
Read as string if the current BsonType is string

### DIFF
--- a/Source/Extensions/MongoDB/ConceptSerializer.cs
+++ b/Source/Extensions/MongoDB/ConceptSerializer.cs
@@ -132,6 +132,10 @@ namespace Cratis.Extensions.MongoDB
 
             if (valueType == typeof(Guid))
             {
+                if (bsonReader.GetCurrentBsonType() == BsonType.String)
+                {
+                    return Guid.Parse(bsonReader.ReadString());
+                }
                 var binaryData = bsonReader.ReadBinaryData();
                 return binaryData.ToGuid();
             }


### PR DESCRIPTION
### Fixed

- Failsafe for the MongoDB serializer of ConceptAs<Guid> - if the Guid is stored as string, we'll try and parse it as a string representation of the Guid.
