### PR TITLE
Fixing lint errors

### DIFF
--- a/Source/Workbench/Events/Web/Exploring/EventHistogram.tsx
+++ b/Source/Workbench/Events/Web/Exploring/EventHistogram.tsx
@@ -72,7 +72,7 @@ export const EventHistogram = (props: EventHistogramProps) => {
 
     if (chartContainer.current) {
         const chart = getChart();
-        chart.setOption(getChartOption(dates, counts));
+        chart!.setOption(getChartOption(dates, counts));
     }
 
     useEffect(() => {
@@ -82,7 +82,7 @@ export const EventHistogram = (props: EventHistogramProps) => {
             chart.resize();
         }
 
-        const listener = () => getChart().resize();
+        const listener = () => getChart()!.resize();
         window.addEventListener('resize', listener);
         return () => window.removeEventListener('resize', listener);
     }, []);
@@ -90,4 +90,4 @@ export const EventHistogram = (props: EventHistogramProps) => {
     return (
         <div className={styles.eventSamplesContainer} ref={chartContainer} />
     );
-}
+};

--- a/Source/Workbench/Events/Web/Exploring/EventLogs.tsx
+++ b/Source/Workbench/Events/Web/Exploring/EventLogs.tsx
@@ -82,7 +82,7 @@ export const EventLogs = () => {
             name: 'Timeline',
             iconProps: { iconName: 'Timeline' },
             onClick: () => {
-                toggleTimeline()
+                toggleTimeline();
                 if (isFilterOpen) toggleFilter();
             }
         },

--- a/Source/Workbench/Events/Web/Navigation.tsx
+++ b/Source/Workbench/Events/Web/Navigation.tsx
@@ -91,5 +91,5 @@ export const Navigation = () => {
                 onLinkClick={navItemClicked}
                 selectedKey={selectedNav} />
         </div>
-    )
-}
+    );
+};

--- a/Source/Workbench/Events/Web/Types/EventTypes.tsx
+++ b/Source/Workbench/Events/Web/Types/EventTypes.tsx
@@ -93,4 +93,4 @@ export const EventTypes = () => {
             </div>
         </div>
     );
-}
+};

--- a/Source/Workbench/Events/Web/package.json
+++ b/Source/Workbench/Events/Web/package.json
@@ -10,8 +10,8 @@
         "build:dev": "webpack --mode=development",
         "start:dev": "webpack serve --mode=development --progress --hot",
         "clean": "tsc -b --clean",
-        "lint": "eslint '**/*.{js,ts,tsx}' --quiet --fix",
-        "lint:ci": "eslint '**/*.{js,ts,tsx}' --quiet",
+        "lint": "eslint '**/*.{ts,tsx}' --quiet --fix",
+        "lint:ci": "eslint '**/*.{ts,tsx}' --quiet",
         "ci": "yarn clean && yarn lint:ci && yarn build",
         "up": "ncu \\!'@cratis/*'"
     },

--- a/Source/Workbench/Events/Web/useDataFrom.ts
+++ b/Source/Workbench/Events/Web/useDataFrom.ts
@@ -26,7 +26,7 @@ const getRouteInfoFrom = (route: string | RouteInfo) => {
     }
 
     return routeInfo;
-}
+};
 
 const areArgumentsEqual = (left: RouteInfo, right: RouteInfo): boolean => {
     const leftKeys = Object.keys(left.arguments);
@@ -41,7 +41,7 @@ const areArgumentsEqual = (left: RouteInfo, right: RouteInfo): boolean => {
     }
 
     return true;
-}
+};
 
 export function useDataFrom<T = any>(route: string | RouteInfo, mapFunction?: Map<T>, dataReadyCallback?: DataReady<T>): [T[], RefreshData] {
     const [data, setData] = useState<T[]>([]);
@@ -80,7 +80,7 @@ export function useDataFrom<T = any>(route: string | RouteInfo, mapFunction?: Ma
         routeInfo.current = getRouteInfoFrom(route);
         template.current = Handlebars.compile(routeInfo.current.template);
         getData();
-    }, [])
+    }, []);
 
     return [data, getData];
-};
+}


### PR DESCRIPTION
## Summary

This PR brings in the ability to have children on models based on events.
When using the C# client API you'll find it as this:

```csharp
[Projection("8fdaaf0d-1291-47b7-b661-2eeba340a520")]
public class AccountsOverviewProjection : IProjectionFor<AccountsOverview>
{
    public void Define(IProjectionBuilderFor<AccountsOverview> builder)
    {
        builder
            .Children(_ => _.DebitAccounts, _ => _
                .IdentifiedBy(_ => _.Id)
                .From<DebitAccountOpened>(_ => _
                    .UsingParentKey(_ => _.Owner)
                    .Set(_ => _.Name).To(_ => _.Name)));
    }
}
```

You model the relationship by telling what is the property on the model that identifies every child, this is to be able to do the correct operation (Add, Remove, Update) on a child. The Event needs to have a property on it that identifies the parent object; the key. As a child relationship is considered a child projection, you have the same capabilities on a child as on a parent.

### Added

- Support for children on objects in projections.

### Fixed

- Internal restructuring for extensibility and improved maintainability across the board.
