### PR TITLE
Upgrading to v11 of Dolittle SDK

### DIFF
--- a/Samples/Dolittle/EventGenerator.cs
+++ b/Samples/Dolittle/EventGenerator.cs
@@ -20,12 +20,12 @@ namespace Sample
     public class EventGenerator : Controller
     {
         static readonly Random _random = new();
-        static readonly Guid[] _accountGuids = new[]
+        static readonly string[] _accountGuids = new[]
         {
-                Guid.Parse("626fb1ab-e74d-4bd9-a519-0e4268499fd6"),
-                Guid.Parse("37e3c5b9-206c-435c-98f1-8971895c5059"),
-                Guid.Parse("43e659e9-3d45-4600-a6db-c4d5b9f0d2b0"),
-                Guid.Parse("200e206f-2796-4e96-952a-5fe64c49f430")
+                "626fb1ab-e74d-4bd9-a519-0e4268499fd6",
+                "37e3c5b9-206c-435c-98f1-8971895c5059",
+                "43e659e9-3d45-4600-a6db-c4d5b9f0d2b0",
+                "200e206f-2796-4e96-952a-5fe64c49f430"
         };
         static readonly string[] _accountNames = new[]
         {
@@ -112,8 +112,8 @@ namespace Sample
                 new EventMetadata(
                     occurred.Value,
                     _accountGuids[account.Value],
-                    eventType.EventType.Id,
-                    eventType.EventType.Generation,
+                    eventType.Identifier,
+                    eventType.Generation,
                     false),
                 new Aggregate(false, Guid.Empty, 0, 0),
                 new EventHorizon(false, 0, DateTimeOffset.MinValue, Guid.Empty),

--- a/Samples/Dolittle/EventLog.cs
+++ b/Samples/Dolittle/EventLog.cs
@@ -48,8 +48,8 @@ namespace Sample
                 new EventMetadata(
                     DateTimeOffset.UtcNow,
                     eventSourceId,
-                    eventType!.EventType.Id,
-                    eventType!.EventType.Generation,
+                    eventType!.Identifier,
+                    eventType!.Generation,
                     false),
                 new Aggregate(false, Guid.Empty, 0, 0),
                 new EventHorizon(false, 0, DateTimeOffset.MinValue, Guid.Empty),

--- a/Source/Extensions/Dolittle/Dolittle.csproj
+++ b/Source/Extensions/Dolittle/Dolittle.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json.Schema" Version="$(NewtonsoftJsonSchema)" />
-        <PackageReference Include="Dolittle.SDK" Version="9.2.0" />
+        <PackageReference Include="Dolittle.SDK" Version="11.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Extensions/Dolittle/EventStore/EventMetadata.cs
+++ b/Source/Extensions/Dolittle/EventStore/EventMetadata.cs
@@ -3,5 +3,5 @@
 
 namespace Cratis.Extensions.Dolittle.EventStore
 {
-    public record EventMetadata(DateTimeOffset Occurred, Guid EventSource, Guid TypeId, uint TypeGeneration, bool Public);
+    public record EventMetadata(DateTimeOffset Occurred, string EventSource, Guid TypeId, uint TypeGeneration, bool Public);
 }

--- a/Source/Extensions/Dolittle/EventTypes.cs
+++ b/Source/Extensions/Dolittle/EventTypes.cs
@@ -30,7 +30,7 @@ namespace Cratis.Extensions.Dolittle
                             .ToDictionary(_ =>
                             {
                                 var eventType = _.GetCustomAttribute<EventTypeAttribute>()!;
-                                return new EventType(eventType.EventType.Id.Value, eventType.EventType.Generation.Value);
+                                return new EventType(eventType.Identifier.Value, eventType.Generation.Value);
                             }, _ => _);
 
             All = _typesByEventType.Keys.ToArray();

--- a/Source/Extensions/Dolittle/Schemas/SchemaStore.cs
+++ b/Source/Extensions/Dolittle/Schemas/SchemaStore.cs
@@ -92,9 +92,9 @@ namespace Cratis.Extensions.Dolittle.Schemas
 
             var typeSchema = _generator.Generate(type);
             typeSchema.SetDisplayName(type.Name);
-            typeSchema.SetGeneration(eventTypeAttribute.EventType.Generation.Value);
+            typeSchema.SetGeneration(eventTypeAttribute.Generation.Value);
 
-            var eventSchema = new EventSchema(eventTypeAttribute.EventType, typeSchema);
+            var eventSchema = new EventSchema(new EventType(eventTypeAttribute.Identifier, eventTypeAttribute.Generation), typeSchema);
             ExtendSchema(type, eventSchema, typeSchema);
 
             return eventSchema;
@@ -111,7 +111,7 @@ namespace Cratis.Extensions.Dolittle.Schemas
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<EventSchema>> GetAllGenerationsForEventType(global::Dolittle.SDK.Events.EventType eventType)
+        public async Task<IEnumerable<EventSchema>> GetAllGenerationsForEventType(EventType eventType)
         {
             var filter = Builders<EventSchemaMongoDB>.Filter.Eq(_ => _.EventType, eventType.Id.Value);
             var all = _collection.Find(_ => _.EventType == eventType.Id.Value).ToList();


### PR DESCRIPTION
### Fixed

- Upgrading to version 11 of the Dolittle SDK - it had some breaking changes that won't affect the exterior from Cratis.