### PR TITLE
Throw exception if trying to get event type id for type without metadata

### DIFF
--- a/Source/Extensions/Dolittle/EventTypes.cs
+++ b/Source/Extensions/Dolittle/EventTypes.cs
@@ -4,6 +4,7 @@
 extern alias SDK;
 
 using System.Reflection;
+using Cratis.Extensions.Dolittle.Schemas;
 using Cratis.Reflection;
 using Cratis.Types;
 using Dolittle.SDK.Events;
@@ -43,7 +44,11 @@ namespace Cratis.Extensions.Dolittle
         public bool HasFor(EventTypeId eventTypeId) => _typesByEventType.Any(_ => _.Key.EventTypeId == eventTypeId);
 
         /// <inheritdoc/>
-        public EventTypeId GetEventTypeIdFor(Type clrType) => _typesByEventType.Single(_ => _.Value == clrType).Key.EventTypeId;
+        public EventTypeId GetEventTypeIdFor(Type clrType)
+        {
+            TypeIsMissingEventType.ThrowIfMissingEventType(clrType);
+            return _typesByEventType.Single(_ => _.Value == clrType).Key.EventTypeId;
+        }
 
         /// <inheritdoc/>
         public bool HasFor(Type clrType) => _typesByEventType.Any(_ => _.Value == clrType);

--- a/Source/Extensions/Dolittle/Schemas/TypeIsMissingEventType.cs
+++ b/Source/Extensions/Dolittle/Schemas/TypeIsMissingEventType.cs
@@ -16,7 +16,7 @@ namespace Cratis.Extensions.Dolittle.Schemas
         /// </summary>
         /// <param name="type">Type that is missing information.</param>
         public TypeIsMissingEventType(Type type)
-            : base($"Type '{type.AssemblyQualifiedName}' does not have any even type information associated with it.")
+            : base($"Type '{type.AssemblyQualifiedName}' does not have any event type information associated with it.")
         {
         }
 


### PR DESCRIPTION
### Fixed

- Throw `TypeIsMissingEventType` if trying to get `EventTypeId` from a type not adorned with `[EventType]`.