### PR TITLE
Saved offset needs to be the next event it will start from (1 indexed)

### DIFF
--- a/Source/Extensions/Dolittle/Projections/ProjectionEventProvider.cs
+++ b/Source/Extensions/Dolittle/Projections/ProjectionEventProvider.cs
@@ -166,8 +166,8 @@ namespace Cratis.Extensions.Dolittle.Projections
                             content));
                 }
 
-                await _projectionPositions.Save(projection, @event.Id);
-                lastSavedPosition = @event.Id;
+                await _projectionPositions.Save(projection, @event.Id + 1);
+                lastSavedPosition = @event.Id + 1;
             }
 
             return lastSavedPosition;


### PR DESCRIPTION
### Fixed

- Fixing so that we save the correct offset for the projection - it needs to be the next event offset it will start processing from.