### PR TITLE
Introducing an interface defining the projection serializer

### DIFF
--- a/Source/Extensions/Dolittle/Projections/Projections.cs
+++ b/Source/Extensions/Dolittle/Projections/Projections.cs
@@ -24,7 +24,7 @@ namespace Cratis.Extensions.Dolittle.Projections
     public class Projections : SDK::Cratis.Events.Projections.Projections
     {
         readonly IMongoDBClientFactory _mongoDBClientFactory;
-        readonly JsonProjectionSerializer _projectionSerializer;
+        readonly IJsonProjectionSerializer _projectionSerializer;
         readonly ILoggerFactory _loggerFactory;
 
         /// <summary>
@@ -33,14 +33,14 @@ namespace Cratis.Extensions.Dolittle.Projections
         /// <param name="eventTypes"><see cref="IEventTypes"/> to use.</param>
         /// <param name="mongoDBClientFactory"><see cref="IMongoDBClientFactory"/> for working with MongoDB.</param>
         /// <param name="types"><see cref="ITypes"/> for type discovery.</param>
-        /// <param name="projectionSerializer"><see cref="JsonProjectionSerializer"/> for serialization of projection definitions.</param>
+        /// <param name="projectionSerializer"><see cref="IJsonProjectionSerializer"/> for serialization of projection definitions.</param>
         /// <param name="projectionsReady"><see cref="ProjectionsReady"/> observable for being notified when projections are ready.</param>
         /// <param name="loggerFactory"><see cref="ILoggerFactory"/> for creating loggers.</param>
         public Projections(
             IEventTypes eventTypes,
             IMongoDBClientFactory mongoDBClientFactory,
             ITypes types,
-            JsonProjectionSerializer projectionSerializer,
+            IJsonProjectionSerializer projectionSerializer,
             ProjectionsReady projectionsReady,
             ILoggerFactory loggerFactory) : base(eventTypes, types)
         {

--- a/Source/Kernel/Events.Projections/Json/IJsonProjectionSerializer.cs
+++ b/Source/Kernel/Events.Projections/Json/IJsonProjectionSerializer.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Events.Projections.Definitions;
+
+namespace Cratis.Events.Projections.Json
+{
+    /// <summary>
+    /// Defines a parser for JSON definition of a <see cref="IProjection"/>.
+    /// </summary>
+    public interface IJsonProjectionSerializer
+    {
+        /// <summary>
+        /// Create a <see cref="IProjection"/> from <see cref="ProjectionDefinition"/>.
+        /// </summary>
+        /// <param name="definition"><see cref="ProjectionDefinition"/> to create from.</param>
+        /// <returns><see cref="IProjection"/> instance.</returns>
+        IProjection CreateFrom(ProjectionDefinition definition);
+
+        /// <summary>
+        /// Deserialize a JSON string definition into <see cref="ProjectionDefinition"/>.
+        /// </summary>
+        /// <param name="json">JSON to parse.</param>
+        /// <returns><see cref="ProjectionDefinition"/> instance.</returns>
+        ProjectionDefinition Deserialize(string json);
+
+        /// <summary>
+        /// Serialize a <see cref="ProjectionDefinition"/>.
+        /// </summary>
+        /// <param name="definition"><see cref="ProjectionDefinition"/> to serialize.</param>
+        /// <returns>JSON representation.</returns>
+        string Serialize(ProjectionDefinition definition);
+    }
+}

--- a/Source/Kernel/Events.Projections/Json/JsonProjectionSerializer.cs
+++ b/Source/Kernel/Events.Projections/Json/JsonProjectionSerializer.cs
@@ -11,9 +11,9 @@ using Newtonsoft.Json.Schema;
 namespace Cratis.Events.Projections.Json
 {
     /// <summary>
-    /// Represents a parser for JSON definition of a <see cref="IProjection"/>.
+    /// Represents an implementation of <see cref="IJsonProjectionSerializer"/>.
     /// </summary>
-    public class JsonProjectionSerializer
+    public class JsonProjectionSerializer : IJsonProjectionSerializer
     {
         readonly IPropertyMapperExpressionResolvers _propertyMapperExpressionResolvers;
         readonly JsonSerializer _serializer;
@@ -34,11 +34,7 @@ namespace Cratis.Events.Projections.Json
             _serializer.Converters.Add(new ConceptAsDictionaryJsonConverter());
         }
 
-        /// <summary>
-        /// Serialize a <see cref="ProjectionDefinition"/>.
-        /// </summary>
-        /// <param name="definition"><see cref="ProjectionDefinition"/> to serialize.</param>
-        /// <returns>JSON representation.</returns>
+        /// <inheritdoc/>
         public string Serialize(ProjectionDefinition definition)
         {
             var writer = new StringWriter();
@@ -46,18 +42,10 @@ namespace Cratis.Events.Projections.Json
             return writer.ToString();
         }
 
-        /// <summary>
-        /// Deserialize a JSON string definition into <see cref="ProjectionDefinition"/>.
-        /// </summary>
-        /// <param name="json">JSON to parse.</param>
-        /// <returns><see cref="ProjectionDefinition"/> instance.</returns>
+        /// <inheritdoc/>
         public ProjectionDefinition Deserialize(string json) => _serializer.Deserialize<ProjectionDefinition>(new JsonTextReader(new StringReader(json)))!;
 
-        /// <summary>
-        /// Create a <see cref="IProjection"/> from <see cref="ProjectionDefinition"/>.
-        /// </summary>
-        /// <param name="definition"><see cref="ProjectionDefinition"/> to create from.</param>
-        /// <returns><see cref="IProjection"/> instance.</returns>
+        /// <inheritdoc/>
         public IProjection CreateFrom(ProjectionDefinition definition) =>
             CreateProjectionFrom(
                 definition,

--- a/Source/Kernel/Events.Projections/MongoDB/MongoDBProjectionDefinitions.cs
+++ b/Source/Kernel/Events.Projections/MongoDB/MongoDBProjectionDefinitions.cs
@@ -14,7 +14,7 @@ namespace Cratis.Events.Projections.MongoDB
     /// </summary>
     public class MongoDBProjectionDefinitions : IProjectionDefinitions
     {
-        readonly JsonProjectionSerializer _projectionSerializer;
+        readonly IJsonProjectionSerializer _projectionSerializer;
         readonly IMongoCollection<BsonDocument> _collection;
 
         /// <summary>
@@ -22,7 +22,7 @@ namespace Cratis.Events.Projections.MongoDB
         /// </summary>
         /// <param name="clientFactory"><see cref="IMongoDBClientFactory"/> for connecting to mongo.</param>
         /// <param name="projectionSerializer">Serializer for <see cref="ProjectionDefinition"/>.</param>
-        public MongoDBProjectionDefinitions(IMongoDBClientFactory clientFactory, JsonProjectionSerializer projectionSerializer)
+        public MongoDBProjectionDefinitions(IMongoDBClientFactory clientFactory, IJsonProjectionSerializer projectionSerializer)
         {
             var settings = MongoClientSettings.FromConnectionString("mongodb://localhost:27017");
 


### PR DESCRIPTION
### Fixed

- Extracting out the interface for the `JsonProjectionSerializer` - enabling mocking in specs internally and externally for anything leveraging custom pipelines.
