### PR TITLE
Putting in place some error handling + fixing filtering on handling

### DIFF
--- a/Samples/Dolittle/ProjectionTesting.cs
+++ b/Samples/Dolittle/ProjectionTesting.cs
@@ -5,7 +5,6 @@ using System.Reactive.Subjects;
 using Cratis.Boot;
 using Cratis.Dynamic;
 using Cratis.Events.Projections;
-using Cratis.Events.Projections.Json;
 
 namespace Sample
 {
@@ -19,7 +18,7 @@ namespace Sample
         {
             public ProjectionEventProviderTypeId TypeId => "edc4e112-0a6f-4c68-86ca-646d789d0541";
 
-            public void ProvideFor(IProjection projection, ISubject<Event> subject)
+            public void ProvideFor(IProjectionPipeline pipeline, ISubject<Event> subject)
             {
                 subject.OnNext(new Event(0, EventTypeA, DateTimeOffset.UtcNow, "d567f175-f940-4f4d-88ee-d96885a78c1a", new { integer = 42, a_string = "Forty Two" }.AsExpandoObject()));
                 subject.OnNext(new Event(0, EventTypeB, DateTimeOffset.UtcNow, "d567f175-f940-4f4d-88ee-d96885a78c1a", new { moreStuff = 43 }.AsExpandoObject()));

--- a/Source/Extensions/Dolittle/Projections/ProjectionEventProvider.cs
+++ b/Source/Extensions/Dolittle/Projections/ProjectionEventProvider.cs
@@ -79,19 +79,12 @@ namespace Cratis.Extensions.Dolittle.Projections
 
                     foreach (var (projectionPipeline, subjects) in _piplinesWithSubjects)
                     {
-                        try
+                        foreach (var subject in subjects)
                         {
-                            foreach (var subject in subjects)
+                            foreach (var @event in cursor.Current.Select(_ => _.FullDocument.ToCratis()))
                             {
-                                foreach (var @event in cursor.Current.Select(_ => _.FullDocument.ToCratis()))
-                                {
-                                    subject.OnNext(@event);
-                                }
+                                subject.OnNext(@event);
                             }
-                        }
-                        catch (Exception ex)
-                        {
-                            projectionPipeline.Suspend($"Exception: {ex.Message}\nStackTrace: {ex.StackTrace}");
                         }
                     }
                 }

--- a/Source/Kernel/Events.Projections/IProjection.cs
+++ b/Source/Kernel/Events.Projections/IProjection.cs
@@ -55,6 +55,13 @@ namespace Cratis.Events.Projections
         IObservable<EventContext> FilterEventTypes(IObservable<EventContext> observable);
 
         /// <summary>
+        /// Apply a filter to an <see cref="IObservable{Event}"/> with the event types the <see cref="Projection"/> is interested in.
+        /// </summary>
+        /// <param name="observable"><see cref="IObservable{Event}"/> to filter.</param>
+        /// <returns>Filtered <see cref="IObservable{Event}"/>.</returns>
+        IObservable<Event> FilterEventTypes(IObservable<Event> observable);
+
+        /// <summary>
         /// Provides the projection with a new <see cref="Event"/>.
         /// </summary>
         /// <param name="event"><see cref="Event"/> to provide.</param>

--- a/Source/Kernel/Events.Projections/IProjectionEventProvider.cs
+++ b/Source/Kernel/Events.Projections/IProjectionEventProvider.cs
@@ -18,7 +18,7 @@ namespace Cratis.Events.Projections
         /// <summary>
         /// Start providing events for a <see cref="IProjection"/>.
         /// </summary>
-        /// <param name="projection"><see cref="IProjection"/> to start providing for.</param>
+        /// <param name="pipeline"><see cref="IProjectionPipeline"/> to start providing for.</param>
         /// <param name="subject"><see cref="ISubject{Event}"/> to provide into.</param>
         /// <returns><see cref="IObservable{T}"/> of <see cref="Event">events</see>.</returns>
         /// <remarks>
@@ -26,7 +26,7 @@ namespace Cratis.Events.Projections
         /// <see cref="IProjection"/>. It will be in a state of catching up till its at the
         /// head of the stream. Once at the head, it will provide events as they occur.
         /// </remarks>
-        void ProvideFor(IProjection projection, ISubject<Event> subject);
+        void ProvideFor(IProjectionPipeline pipeline, ISubject<Event> subject);
 
         /// <summary>
         /// Get events from a specific sequence numbers.

--- a/Source/Kernel/Events.Projections/IProjectionPipeline.cs
+++ b/Source/Kernel/Events.Projections/IProjectionPipeline.cs
@@ -46,22 +46,33 @@ namespace Cratis.Events.Projections
         /// <summary>
         /// Starts the pipeline.
         /// </summary>
+        /// <returns>A Task for async operations.</returns>
         Task Start();
 
         /// <summary>
         /// Resumes the pipeline if paused.
         /// </summary>
+        /// <returns>A Task for async operations.</returns>
         Task Resume();
 
         /// <summary>
         /// Pause the pipeline.
         /// </summary>
+        /// <returns>A Task for async operations.</returns>
         Task Pause();
 
         /// <summary>
         /// Rewind the entire pipeline for all the result stores.
         /// </summary>
+        /// <returns>A Task for async operations.</returns>
         Task Rewind();
+
+        /// <summary>
+        /// Suspend a pipeline with a reason.
+        /// </summary>
+        /// <param name="reason">The reason for the suspension.</param>
+        /// <returns>A Task for async operations.</returns>
+        Task Suspend(string reason);
 
         /// <summary>
         /// Rewind the entire pipeline for a specific result store based on the unique identifier.

--- a/Source/Kernel/Events.Projections/Projection.cs
+++ b/Source/Kernel/Events.Projections/Projection.cs
@@ -48,6 +48,9 @@ namespace Cratis.Events.Projections
         public IObservable<EventContext> FilterEventTypes(IObservable<EventContext> observable) => observable.Where(_ => EventTypes.Any(et => et == _.Event.Type));
 
         /// <inheritdoc/>
+        public IObservable<Event> FilterEventTypes(IObservable<Event> observable) => observable.Where(_ => EventTypes.Any(et => et == _.Type));
+
+        /// <inheritdoc/>
         public ProjectionId Identifier { get; }
 
         /// <inheritdoc/>

--- a/Source/Kernel/Events.Projections/ProjectionPipeline.cs
+++ b/Source/Kernel/Events.Projections/ProjectionPipeline.cs
@@ -136,6 +136,14 @@ namespace Cratis.Events.Projections
         }
 
         /// <inheritdoc/>
+        public Task Suspend(string reason)
+        {
+            _logger.Suspended(Projection.Identifier, reason);
+            _state.OnNext(ProjectionState.Suspended);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
         public void StoreIn(ProjectionResultStoreConfigurationId configurationId, IProjectionResultStore resultStore)
         {
             _resultStores[configurationId] = resultStore;
@@ -175,8 +183,10 @@ namespace Cratis.Events.Projections
                     _rewindsPerConfiguration.Remove(configurationId, out _);
 
                     var subject = _subjectsPerConfiguration[configurationId];
-                    EventProvider.ProvideFor(Projection, subject);
-                    _subscriptionsPerConfiguration[configurationId] = subject.Subscribe(@event => OnNext(@event, resultStore, configurationId).Wait());
+                    EventProvider.ProvideFor(this, subject);
+                    _subscriptionsPerConfiguration[configurationId] = Projection
+                        .FilterEventTypes(subject)
+                        .Subscribe(@event => OnNext(@event, resultStore, configurationId).Wait());
 
                     if (_catchUpPerConfiguration.IsEmpty)
                     {
@@ -186,7 +196,7 @@ namespace Cratis.Events.Projections
                 catch (Exception ex)
                 {
                     _logger.ErrorStartingProviding(Projection.Identifier, ex);
-                    _state.OnNext(ProjectionState.Failed);
+                    _state.OnNext(ProjectionState.Suspended);
                 }
             }, cancellationTokenSource.Token);
 
@@ -257,6 +267,8 @@ namespace Cratis.Events.Projections
 
         async Task HandleEventFor(IProjection projection, IProjectionResultStore resultStore, Event @event, List<Changeset<Event, ExpandoObject>> changesets)
         {
+            if (CurrentState == ProjectionState.Suspended) return;
+
             var keyResolver = projection.GetKeyResolverFor(@event.Type);
             var key = keyResolver(@event);
             _logger.GettingInitialValues(@event.SequenceNumber);

--- a/Source/Kernel/Events.Projections/ProjectionPipelineLogMessages.cs
+++ b/Source/Kernel/Events.Projections/ProjectionPipelineLogMessages.cs
@@ -38,5 +38,8 @@ namespace Cratis.Events.Projections
 
         [LoggerMessage(9, LogLevel.Error, "Error starting projection '{Projection}'")]
         internal static partial void ErrorStartingProviding(this ILogger logger, ProjectionId projection, Exception exception);
+
+        [LoggerMessage(10, LogLevel.Warning, "Projection '{Projection}' is being suspended with the reason '{reason}'")]
+        internal static partial void Suspended(this ILogger logger, ProjectionId projection, string reason);
     }
 }

--- a/Source/Kernel/Events.Projections/ProjectionState.cs
+++ b/Source/Kernel/Events.Projections/ProjectionState.cs
@@ -49,8 +49,8 @@ namespace Cratis.Events.Projections
         Stopped = 7,
 
         /// <summary>
-        /// Projection has failed.
+        /// Projection is suspended, most likely due to failure.
         /// </summary>
-        Failed = 8
+        Suspended = 8
     }
 }

--- a/Specifications/Kernel/Events.Projections/for_ProjectionPipeline/given/all_dependencies.cs
+++ b/Specifications/Kernel/Events.Projections/for_ProjectionPipeline/given/all_dependencies.cs
@@ -23,7 +23,6 @@ namespace Cratis.Events.Projections.for_ProjectionPipeline.given
             changeset_storage = new();
             projection_positions = new();
             subject = new();
-            event_provider.Setup(_ => _.ProvideFor(projection.Object, subject.Object));
         }
     }
 }


### PR DESCRIPTION
### Added

- Suspended state for a projection. Typically if a projection fails for some reason.

### Fixed

- Filter on event types per projection on the subjects created in the pipeline.
- Error handling when providing events.
