### PR TITLE
Fix-concept-types-for-schemas

### DIFF
--- a/Source/Clients/AspNetCore.Workbench/AspNetCore.Workbench.csproj
+++ b/Source/Clients/AspNetCore.Workbench/AspNetCore.Workbench.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
         <ProjectReference Include="../../Fundamentals/Fundamentals.csproj" />
+        <ProjectReference Include="../../Kernel/Events.Schemas.Api/Events.Schemas.Api.csproj" />
         <ProjectReference Include="../../Kernel/Events.Projections.Api/Events.Projections.Api.csproj" />
     </ItemGroup>
 

--- a/Source/Fundamentals/Schemas/ReflectionService.cs
+++ b/Source/Fundamentals/Schemas/ReflectionService.cs
@@ -17,6 +17,7 @@ namespace Cratis.Schemas
         {
             if (contextualType.Type.IsConcept())
             {
+                defaultReferenceTypeNullHandling = ReferenceTypeNullHandling.NotNull;
                 contextualType = contextualType.Type.GetConceptValueType().ToContextualType();
             }
 


### PR DESCRIPTION
### Fixed

- Event Type workbench working again - it was not referenced in the output.
- Generating correct type info for concept types. Showing the underlying type.
