### PR TITLE
Set a timeout for yarn to get more reliable builds

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -29,6 +29,9 @@ WORKDIR /build
 COPY --from=shared /build/ .
 
 WORKDIR /build/Source/Workbench/Events/Web
+
+# Set network timeout manually as a workaround till we're on Yarn 2: https://github.com/yarnpkg/yarn/issues/8242#issuecomment-661881292
+RUN yarn config set network-timeout 300000
 RUN yarn
 RUN yarn build
 


### PR DESCRIPTION
### Fixed

- Setting Yarn timeout in Dockerfile to avoid getting **ESOCKETTIMEDOUT** during Yarn install (as suggested [here](https://github.com/yarnpkg/yarn/issues/8242#issuecomment-661881292). This is till we've upgraded to Yarn 2.0 that should have this fixed.
