### PR TITLE
Using identified by when parentkey is not used

### DIFF
--- a/Source/Kernel/Projections/Engine/IProjectionFactory.cs
+++ b/Source/Kernel/Projections/Engine/IProjectionFactory.cs
@@ -15,6 +15,6 @@ namespace Cratis.Events.Projections
         /// </summary>
         /// <param name="definition"><see cref="ProjectionDefinition"/> to create from.</param>
         /// <returns>A new <see cref="IProjection"/> instance.</returns>
-        IProjection CreateFrom(ProjectionDefinition definition);
+        Task<IProjection> CreateFrom(ProjectionDefinition definition);
     }
 }

--- a/Source/Kernel/Projections/Engine/ProjectionFactory.cs
+++ b/Source/Kernel/Projections/Engine/ProjectionFactory.cs
@@ -74,7 +74,8 @@ namespace Cratis.Events.Projections
                 foreach (var (eventType, fromDefinition) in childrenDefinition.From)
                 {
                     var propertyMappers = fromDefinition.Properties.Select(kvp => _propertyMapperExpressionResolvers.Resolve(kvp.Key, kvp.Value));
-                    projection.Event.From(eventType).Child(childrenProperty, childrenDefinition.IdentifiedBy, EventValueProviders.FromEventSourceId, propertyMappers);
+                    var keyResolver = string.IsNullOrEmpty(fromDefinition.ParentKey) ? EventValueProviders.FromEventContent(childrenDefinition.IdentifiedBy) : EventValueProviders.FromEventSourceId;
+                    projection.Event.From(eventType).Child(childrenProperty, childrenDefinition.IdentifiedBy, keyResolver, propertyMappers);
                 }
             }
 

--- a/Source/Kernel/Projections/Engine/Projections.cs
+++ b/Source/Kernel/Projections/Engine/Projections.cs
@@ -55,7 +55,7 @@ namespace Cratis.Events.Projections
         /// <inheritdoc/>
         public async Task Register(ProjectionDefinition projectionDefinition, ProjectionPipelineDefinition pipelineDefinition)
         {
-            var projection = _projectionFactory.CreateFrom(projectionDefinition);
+            var projection = await _projectionFactory.CreateFrom(projectionDefinition);
             var pipeline = _pipelineFactory.CreateFrom(projection, pipelineDefinition);
             var isNew = !await _projectionDefinitions.HasFor(projectionDefinition.Identifier);
             var hasChanged = await _projectionDefinitions.HasChanged(projectionDefinition);

--- a/Specifications/Kernel/Projections/Engine/for_Projections/given/no_projections.cs
+++ b/Specifications/Kernel/Projections/Engine/for_Projections/given/no_projections.cs
@@ -46,7 +46,7 @@ namespace Cratis.Events.Projections.for_Projections.given
                 "dc5366eb-d453-43c9-859f-64989a858e7c",
                 Array.Empty<ProjectionResultStoreDefinition>());
 
-            projection_factory.Setup(_ => _.CreateFrom(projection_definition)).Returns(projection.Object);
+            projection_factory.Setup(_ => _.CreateFrom(projection_definition)).Returns(Task.FromResult(projection.Object));
             pipeline_factory.Setup(_ => _.CreateFrom(projection.Object, pipeline_definition)).Returns(pipeline.Object);
         }
     }

--- a/Specifications/Kernel/Projections/Engine/for_Projections/when_starting_with_one_definition_unregistered_and_one_registered.cs
+++ b/Specifications/Kernel/Projections/Engine/for_Projections/when_starting_with_one_definition_unregistered_and_one_registered.cs
@@ -42,7 +42,7 @@ namespace Cratis.Events.Projections.for_Projections
             unregistered_projection.SetupGet(_ => _.Identifier).Returns(unregistered_projection_identifier);
             unregistered_pipeline = new();
             unregistered_pipeline.SetupGet(_ => _.Projection).Returns(unregistered_projection.Object);
-            projection_factory.Setup(_ => _.CreateFrom(unregistered_projection_definition)).Returns(unregistered_projection.Object);
+            projection_factory.Setup(_ => _.CreateFrom(unregistered_projection_definition)).Returns(Task.FromResult(unregistered_projection.Object));
             pipeline_factory.Setup(_ => _.CreateFrom(unregistered_projection.Object, unregistered_pipeline_definition)).Returns(unregistered_pipeline.Object);
 
             projections.Pipelines.Subscribe(_ => pipeline_registered = _);


### PR DESCRIPTION
## Summary

Improved consistent behavior for child relationships.
Events that represent something that is related to the same event source id as another event can now be modelled in a projection as a child. 

Take the following:

```csharp
public void Define(IProjectionBuilderFor<Person> builder) => builder
    .From<PersonRegistered>(_ => _
        .Set(m => m.SocialSecurityNumber).To(e => e.SocialSecurityNumber)
        .Set(m => m.FirstName).To(e => e.FirstName)
        .Set(m => m.LastName).To(e => e.LastName))
    .Children(_ => _.PersonalInformation, c => c
        .IdentifiedBy(_ => _.Identifier)
        .From<PersonalInformationRegistered>(_ => _
            .UsingKey(_ => _.Identifier)
            .Set\(m => m.Type).To(e => e.Type)
            .Set\(m => m.Value).To(e => e.Value)));
```

With the child definition, it will identify the child uniquely based on the `IdentifiedBy` statement. This tells the engine to use the property `Identifier` on the target read model / document to identify it.
Within the child definition from statements can now specify a property on the event to be used as the key. The statement `UsingKey()` accomplishes this. This will then direct the projection engine to use this property to identify the child object and map this with the `IdentifiedBy()` property on the read model / document. 

The point of this all is to be able to share the event source id - being the aggregate identifier for all things related. While the child identifier is the value identifier.


### Fixed

- When `ParentKey()` is not specified in a child relationship, one can use the `UsingKey()` to specify a property on the child to be the key that identifies the child.

