### PR TITLE
Adding simple cache for keys

### DIFF
--- a/Source/Extensions/MongoDB/MongoDBDefaults.cs
+++ b/Source/Extensions/MongoDB/MongoDBDefaults.cs
@@ -17,10 +17,10 @@ namespace Cratis.Extensions.MongoDB
     [Singleton]
     public class MongoDBDefaults
     {
+        static bool _initialized;
         readonly IInstancesOf<ICanFilterMongoDBConventionPacksForType> _conventionPackFilters;
         readonly ITypes _types;
         readonly IServiceProvider _serviceProvider;
-        bool _initialized;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoDBDefaults"/> class.

--- a/Source/Kernel/Compliance/Engine/CacheEncryptionKeyStore.cs
+++ b/Source/Kernel/Compliance/Engine/CacheEncryptionKeyStore.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Compliance
+{
+    /// <summary>
+    /// Represents an implementation of <see cref="IEncryptionKeyStore"/> that works as a configurable cache in front of another <see cref="IEncryptionKeyStore"/>.
+    /// </summary>
+    public class CacheEncryptionKeyStore : IEncryptionKeyStore
+    {
+        readonly IEncryptionKeyStore _actualKeyStore;
+        readonly Dictionary<EncryptionKeyIdentifier, EncryptionKey> _keys = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CacheEncryptionKeyStore"/> class.
+        /// </summary>
+        /// <param name="actualKeyStore">Actual <see cref="IEncryptionKeyStore"/>.</param>
+        public CacheEncryptionKeyStore(IEncryptionKeyStore actualKeyStore)
+        {
+            _actualKeyStore = actualKeyStore;
+        }
+
+        /// <inheritdoc/>
+        public async Task DeleteFor(EncryptionKeyIdentifier identifier)
+        {
+            _keys.Remove(identifier);
+            await _actualKeyStore.DeleteFor(identifier);
+        }
+
+        /// <inheritdoc/>
+        public async Task<EncryptionKey> GetFor(EncryptionKeyIdentifier identifier)
+        {
+            if (_keys.ContainsKey(identifier))
+            {
+                return _keys[identifier];
+            }
+
+            return _keys[identifier] = await _actualKeyStore.GetFor(identifier);
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> HasFor(EncryptionKeyIdentifier identifier)
+        {
+            if (_keys.ContainsKey(identifier))
+            {
+                return true;
+            }
+
+            return await _actualKeyStore.HasFor(identifier);
+        }
+
+        /// <inheritdoc/>
+        public async Task SaveFor(EncryptionKeyIdentifier identifier, EncryptionKey key)
+        {
+            _keys[identifier] = key;
+            await _actualKeyStore.SaveFor(identifier, key);
+        }
+    }
+}

--- a/Source/Kernel/Server/Program.cs
+++ b/Source/Kernel/Server/Program.cs
@@ -46,7 +46,7 @@ namespace Cratis.Server
                     .ConfigureServices(_ => _
                         .AddSingleton<IProjectionPositions, MongoDBProjectionPositions>()
                         .AddSingleton<IChangesetStorage, MongoDBChangesetStorage>()
-                        .AddSingleton<IEncryptionKeyStore, MongoDBEncryptionKeyStore>()
+                        .AddSingleton<IEncryptionKeyStore>(sp => new CacheEncryptionKeyStore(sp.GetService<MongoDBEncryptionKeyStore>()!))
                         .AddSingleton<ISchemaStore, MongoDBSchemaStore>()
                         .AddSingleton<IProjectionDefinitionsStorage, MongoDBProjectionDefinitionsStorage>()
                         .AddSingleton<IProjectionPipelineDefinitionsStorage, MongoDBProjectionPipelineDefinitionsStorage>()

--- a/Specifications/Kernel/Compliance/Engine/for_CacheEncryptionKeyStore/given/a_cache_encryption_key_store.cs
+++ b/Specifications/Kernel/Compliance/Engine/for_CacheEncryptionKeyStore/given/a_cache_encryption_key_store.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Compliance.Engine.for_CacheEncryptionKeyStore.given
+{
+    public class a_cache_encryption_key_store : Specification
+    {
+        protected CacheEncryptionKeyStore   store;
+        protected Mock<IEncryptionKeyStore> actual_store;
+
+        void Establish()
+        {
+            actual_store = new();
+            store = new(actual_store.Object);
+        }
+    }
+}

--- a/Specifications/Kernel/Compliance/Engine/for_CacheEncryptionKeyStore/when_checking_if_has_for/and_cache_does_not_have_it.cs
+++ b/Specifications/Kernel/Compliance/Engine/for_CacheEncryptionKeyStore/when_checking_if_has_for/and_cache_does_not_have_it.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Compliance.Engine.for_CacheEncryptionKeyStore.when_checking_if_has_for
+{
+    public class and_cache_does_not_have_it : given.a_cache_encryption_key_store
+    {
+        static EncryptionKeyIdentifier identifier = "5c6cce36-d60d-46db-9db2-e820559962db";
+        bool result;
+
+        void Establish() => actual_store.Setup(_ => _.HasFor(identifier)).Returns(Task.FromResult(true));
+
+        async Task Because() => result = await store.HasFor(identifier);
+
+        [Fact] void should_ask_actual_store() => actual_store.Verify(_ => _.HasFor(identifier), Once());
+        [Fact] void should_return_result_from_actual_store() => result.ShouldBeTrue();
+    }
+}

--- a/Specifications/Kernel/Compliance/Engine/for_CacheEncryptionKeyStore/when_checking_if_has_for/and_cache_has_it.cs
+++ b/Specifications/Kernel/Compliance/Engine/for_CacheEncryptionKeyStore/when_checking_if_has_for/and_cache_has_it.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Compliance.Engine.for_CacheEncryptionKeyStore.when_checking_if_has_for
+{
+    public class and_cache_has_it : given.a_cache_encryption_key_store
+    {
+        static EncryptionKeyIdentifier identifier = "5c6cce36-d60d-46db-9db2-e820559962db";
+        bool result;
+
+        Task Establish() => store.SaveFor(identifier, new(Array.Empty<byte>(), Array.Empty<byte>()));
+
+        async Task Because() => result = await store.HasFor(identifier);
+
+        [Fact] void should_not_ask_actual_store() => actual_store.Verify(_ => _.HasFor(identifier), Never());
+        [Fact] void should_have_it_in_cache() => result.ShouldBeTrue();
+    }
+}

--- a/Specifications/Kernel/Compliance/Engine/for_CacheEncryptionKeyStore/when_checking_if_has_for/and_everything_is_empty.cs
+++ b/Specifications/Kernel/Compliance/Engine/for_CacheEncryptionKeyStore/when_checking_if_has_for/and_everything_is_empty.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Compliance.Engine.for_CacheEncryptionKeyStore.when_checking_if_has_for
+{
+    public class and_everything_is_empty : given.a_cache_encryption_key_store
+    {
+        static EncryptionKeyIdentifier identifier = "5c6cce36-d60d-46db-9db2-e820559962db";
+        bool result;
+
+        void Establish() => actual_store.Setup(_ => _.HasFor(identifier)).Returns(Task.FromResult(false));
+
+        async Task Because() => result = await store.HasFor(identifier);
+
+        [Fact] void should_not_have_key() => result.ShouldBeFalse();
+    }
+}

--- a/Specifications/Kernel/Compliance/Engine/for_CacheEncryptionKeyStore/when_deleting.cs
+++ b/Specifications/Kernel/Compliance/Engine/for_CacheEncryptionKeyStore/when_deleting.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Compliance.Engine.for_CacheEncryptionKeyStore
+{
+    public class when_deleting : given.a_cache_encryption_key_store
+    {
+        static EncryptionKeyIdentifier identifier = "5c6cce36-d60d-46db-9db2-e820559962db";
+        static EncryptionKey key = new(Array.Empty<byte>(), Array.Empty<byte>());
+
+        Task Establish() => store.SaveFor(identifier, key);
+
+        Task Because() => store.DeleteFor(identifier);
+
+        [Fact] void should_delete_key_from_actual_store() => actual_store.Verify(_ => _.DeleteFor(identifier), Once());
+        [Fact] async Task should_not_have_the_key_anymore() => (await store.HasFor(identifier)).ShouldBeFalse();
+    }
+}

--- a/Specifications/Kernel/Compliance/Engine/for_CacheEncryptionKeyStore/when_saving.cs
+++ b/Specifications/Kernel/Compliance/Engine/for_CacheEncryptionKeyStore/when_saving.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Compliance.Engine.for_CacheEncryptionKeyStore
+{
+    public class when_saving : given.a_cache_encryption_key_store
+    {
+        static EncryptionKeyIdentifier identifier = "5c6cce36-d60d-46db-9db2-e820559962db";
+        static EncryptionKey key = new(Array.Empty<byte>(), Array.Empty<byte>());
+
+        Task Because() => store.SaveFor(identifier, key);
+
+        [Fact] void should_save_key_to_actual_store() => actual_store.Verify(_ => _.SaveFor(identifier, key), Once());
+        [Fact] async Task should_have_the_key_anymore() => (await store.HasFor(identifier)).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
### Added

- Adding a simple inmemory cache that can sit in front of any other `EncrpyptionKeyStore`. Configured for the MongoDB one in kernel right now.

### Fixed

- Hopefully fixing #112 - needs verification since its not consistently happening.
